### PR TITLE
Update to modSearchResults function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -130,7 +130,6 @@ modSearchResults <- function (df, n = 5)
 {
   ## Define the metric to be used in order to determine the 
   ## best-performing models.
-  
   n <- ifelse(n < length(unique(df$method)), n, length(unique(df$method)))
   if (names(df)[1] == "RMSE") {
     dv <- "RMSE"
@@ -154,9 +153,13 @@ modSearchResults <- function (df, n = 5)
   
   ## Calculate the performance of each individual model and
   ## rank them by that performance.
+  teststats$method <- as.character(teststats$method)
+  teststats$grp <- NULL
+  names(teststats)[names(teststats) == dv] <- "maxdv"
   
-  eval(parse(text=paste("temp <- ddply(teststats, .(method), summarize,
-                        maxdv = max(", dv, ", na.rm=TRUE))", sep="")))
+  eval(parse(text=paste("temp <- aggregate(teststats, by=list(teststats$method), 
+                        FUN=max, na.rm=TRUE)", sep="")))
+  temp <- temp[,match(c("method", "maxdv"), names(temp))]
   
   topMetric <- temp[is.finite(temp$maxdv),]
   badMetric <- temp[is.finite(temp$maxdv),]


### PR DESCRIPTION
Previously, the modSearchResults function would return a vector called "BestMethod", but the model methods in this vector appeared in a random order, rather than ranked by their performance in accordance with the numeric stats returned in the "topMetric" vector. These updates to the modSearchResults function return top-performing models in the correct order, with the top-performing model appearing first in the list of models, and with each model method in the BestMethod vector corresponding to the values in the topMetric vector.  The use of ddply has been removed from the first pull request.
